### PR TITLE
DS9 for python3

### DIFF
--- a/DS9.py
+++ b/DS9.py
@@ -157,7 +157,7 @@ import warnings
 import RO.OS
 import subprocess
 
-_DebugSetup = False
+_DebugSetup = True
 
 def _addToPATH(newPath):
     """Add newPath to the PATH environment variable.
@@ -440,8 +440,8 @@ def xpaset(cmd, data=None, dataFunc=None, template=_DefTemplate, doRaise = False
             dataFunc(p.stdin)
         elif data:
             p.stdin.write(data)
-            if data[-1] != "\n":
-                p.stdin.write("\n")
+            if data[-1] != b"\n":
+                p.stdin.write(b"\n")
         p.stdin.close()
         reply = p.stdout.read()
         if reply:
@@ -510,7 +510,6 @@ def _splitDict(inDict, keys):
         if key in inDict:
             outDict[key] = inDict.pop(key)
     return outDict  
-
 
 class DS9Win:
     """An object that talks to a particular window on ds9
@@ -632,13 +631,16 @@ class DS9Win:
             arryDict["arch"] = "bigendian"
         else:
             arryDict["arch"] = "littleendian"
-            
+        
         self.xpaset(
             cmd = "array [%s]" % (_formatOptions(arryDict),),
-            dataFunc = arr.tofile,
+            #dataFunc = arr.tofile,
+            #fix for python3
+            dataFunc = lambda f: f.write(arr.tobytes()) ,
         )
         
         for keyValue in kargs.items():
+            
             self.xpaset(cmd=" ".join(keyValue))
 
 # showBinFile is commented out because it is broken with ds9 3.0.3
@@ -726,6 +728,10 @@ class DS9Win:
         
         Raises RuntimeError if anything is written to stdout or stderr.
         """
+        if data is not None: 
+            #fix python3
+            data=data.encode()
+        
         return xpaset(
             cmd = cmd,
             data = data,

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # RO3
 
 Russel Owen's library ported to Python 3.
+
+Modification of original RO3 (https://github.com/ApachePointObservatory/RO3) to work with Python 3.12 and the newest version of numpy and astropy. Fixed only the DS9.py file (open images in SAO DS9)! Tested on numpy 1.26.0 and astropy 6.1.2.


### PR DESCRIPTION
I just made some modifications to the DS9.py file to work under python3 with PyGuide - show the image in SAO DS9.